### PR TITLE
fixing music never stopping bug

### DIFF
--- a/Assets/Scenes/Vu Test.unity
+++ b/Assets/Scenes/Vu Test.unity
@@ -186,6 +186,10 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: -336.16
       objectReference: {fileID: 0}
+    - target: {fileID: 4583963617398066771, guid: c7f8f7fb4292ac84aa2418aead199d09, type: 3}
+      propertyPath: TriggerOnce
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 4583963617398066776, guid: c7f8f7fb4292ac84aa2418aead199d09, type: 3}
       propertyPath: m_Name
       value: PlayerPerformance

--- a/Assets/Scripts/GameStateManager.cs
+++ b/Assets/Scripts/GameStateManager.cs
@@ -242,12 +242,13 @@ public class GameStateManager : CustomSingleton<GameStateManager>
     {
         Debug.Log("GameStateManager.PlayFMODFromLastMarker(): Fired.");
 
-        musicEmitter.Play();
+        //musicEmitter.Play();
         musicEmitter.SetParameter("NumFails", NumFails);
         _musicEventInstance = musicEmitter.EventInstance;
         _musicEventInstance.setTimelinePosition(GetCurrMarkerTimelinePos());
         Debug.Log("Restarting at time: " + _currMarker.Value.position);
         _musicEventInstance.setCallback(_musicFmodCallback, FMOD.Studio.EVENT_CALLBACK_TYPE.TIMELINE_BEAT | FMOD.Studio.EVENT_CALLBACK_TYPE.TIMELINE_MARKER);
+        _musicEventInstance.setPaused(false);
         ambienceEmitter.Stop();
         UpdateGameState(0);
     }
@@ -296,7 +297,8 @@ public class GameStateManager : CustomSingleton<GameStateManager>
         Conductor.Instance.Pause();
 
         //Stop Music
-        musicEmitter.Stop();
+        //musicEmitter.Stop();
+        _musicEventInstance.setPaused(true);
         sfxEmitter.Play();
         _failureState = NumFails >= 3 ? FailureState.GameOver : FailureState.Failed;
 


### PR DESCRIPTION
Fixed bug where music never stopped. Caused because musicEvent.Play() would create a new event emitter. Fixed by just pausing the fmod event instance and unpausing it when a level starts. 